### PR TITLE
Fix top_p to define threshold similarly to top_k and not garble output.

### DIFF
--- a/routing_transformer/autoregressive_wrapper.py
+++ b/routing_transformer/autoregressive_wrapper.py
@@ -14,12 +14,12 @@ def top_p(logits, thres = 0.9):
     sorted_logits, sorted_indices = torch.sort(logits, descending=True)
     cum_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
 
-    sorted_indices_to_remove = cum_probs > thres
+    sorted_indices_to_remove = cum_probs > 1.0 - thres
     sorted_indices_to_remove[:, 1:] = sorted_indices_to_remove[:, :-1].clone()
     sorted_indices_to_remove[:, 0] = 0
 
     sorted_logits[sorted_indices_to_remove] = float('-inf')
-    return sorted_logits.gather(1, sorted_indices)
+    return sorted_logits.scatter(1, sorted_indices, sorted_logits)
 
 def top_k(logits, thres = 0.9):
     k = int((1 - thres) * logits.shape[-1])


### PR DESCRIPTION
Fixes #1 . This change switches the way threshold is defined so that 0.9 means accept the top 10% of probabilities, rather than the top 90%. It also replaces the second gather with a scatter. The second gather was shuffling the results in a meaningless way.